### PR TITLE
feat(contextual-help): run tests against feature branch in ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 build/*.js
 build/reports
 fonts
+contextual-help.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: node_js
 sudo: false
 node_js:
 - 5.2
-- 4.2
+#- 4.2
 script:
 - npm run ci
+- chmod 777 ./test/shell_scripts/run_tests.sh
+- ./test/shell_scripts/run_tests.sh
 after_success:
 - cat ./build/reports/coverage/coverage.lcov | node_modules/coveralls/bin/coveralls.js
 after_failure:
@@ -19,3 +21,6 @@ deploy:
   on:
     branch: master
     tags: true
+env:
+  global:
+    secure: KshEOlSNvHFze/OIOtJIxbEoPmzhWtui9xjIt4+ozfqp11FtYNnxURLMYHpCt+uESQOmhFFPINHyyQ7Dmai9qDnMnEqv7dKBBSooG57fzIpghZMWIn13VJr5UP64w88J1jPT0nMnWwBc4OFUYJy6PKTaI48BGiZ28RbXiuXOD1XXG9W3HmMF/eJGTzrfMOD7erxKt9UGPlIHYYNKefA9ZWAmU7osK5UEwSTKNME/z3i+orl9gQjyFqydUOmUxDHP04nr7jkSC1S+pfyuQwWl6bFf5teGDE5Pnl+RXB4r42plFpNk449wMz/lBblXpbOOFIjnH612sebtRIA8ZpKZMeePc56UUTzrBoidiEmpKCI7Z5P+Wfddaa1ms+BeOmFFu21kCFmvpd7jTrtH8J8b0Sy9Azn3va2+XwScBF22kDzwXUMk1uOS4ETeO9IpUN6fH0bjs2oThxgtmmc+64jS5jdz8ecdowCicFd1FtZ1OiI3TKEuDMRbBsg/60CBiKy5aVGUGNnd5G8YSfTM/eZPSjdcuk3YF78cww8LOu1scnphY7Po43RQde/oJUXnEynMo0S3q4m9E4ReRFGRTYHUl/A1XwAC79y+n0P+cbc6BBXNCKHX7L5DRtQjGOy+MaWky/ZDhf7c0r7VkpRapzCze9N7tsVAWaaJqpU3jQrmQsY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: false
 node_js:
 - 5.2
-#- 4.2
+- 4.2
 script:
 - npm run ci
 - chmod 777 ./test/shell_scripts/run_tests.sh

--- a/test/shell_scripts/run_tests.sh
+++ b/test/shell_scripts/run_tests.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+echo "Trigger the Selenium tests for master branch: ux-test-platform repo...."
+
+#Step 1: API to trigger the ux-test-platform build with the below config
+body="{
+\"request\": {
+\"message\": \"feat(contextual-help): Run Contextual Help Tests\",
+\"branch\":\"master\",
+\"config\": {
+\"script\": [
+\"export component=contextual-help\",
+\"export feature_branch=$TRAVIS_BRANCH\",
+\"chmod 777 ./src/main/shell_scripts/components.sh\",
+\"./src/main/shell_scripts/components.sh\",
+\"mvn -Dtest_suite_xml=contextual_help.xml test\"
+]
+}
+}}"
+
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "Travis-API-Version: 3" \
+  -H "Authorization: token $AUTH_TOKEN" \
+  -d "$body" \
+  https://api.travis-ci.org/repo/Pearson-Higher-Ed%2Fux-test-platform/requests
+
+echo ""
+echo "Waiting for approximately 5s for the Selenium tests to trigger..."
+echo ""
+
+REPO_URI="https://api.travis-ci.org/repos/Pearson-Higher-Ed/ux-test-platform/builds"
+i=1
+max=20
+while [ $i -lt $max ]
+do  
+  curl -i $REPO_URI > test.json #Push the json response to a temp file 'test.json'
+
+  LATEST_STATE=$(grep -o '"state":.[a-z\"]*' test.json | head -1 ) #Fetch the state of the last build
+  LATEST_ID=$(grep -o '"id":.[0-9]*' test.json | head -1  | grep ':.[0-9]*') #Fetch the id of the last build
+  BRANCH=$(grep -o '"branch":.[a-z\"]*' test.json | head -1 ) #Fetch the branch name of the last build
+
+  get_state_value=${BRANCH#*:}
+  BRANCH="${get_state_value//\"}"
+
+  if [ $BRANCH == "master" ] #If condition to check if the last triggered build is master
+    sleep 5
+    curl -i $REPO_URI > test.json
+  then LATEST_ID=$(grep -o '"id":.[0-9]*' test.json | head -1  | grep ':.[0-9]*') #
+  echo "LATEST_ID of master branch.............................. $LATEST_ID"
+  export LATEST_ID
+    break 
+  else  
+    true $(( i++ ))
+    sleep 1
+  fi
+done
+
+#Step 2 : Fetch the build status of the 'master' branch
+get_buildId_value=${LATEST_ID#*:}
+BUILD_ID="${get_buildId_value//\"}"
+
+REPO_URI_WITH_BUILDID="$REPO_URI/$BUILD_ID"
+echo $REPO_URI_WITH_BUILDID
+
+i=1
+max=900 #Max time for the tests to run.
+while [ $i -lt $max ]
+do
+
+curl -i $REPO_URI_WITH_BUILDID > test.json 
+
+STATE=$(grep -o '"state":.[a-z\"]*' test.json | head -1 ) #Fetch the state of master build
+#RESULT=$(grep -o '"result":.[0-9]*' test.json | head -1  | grep ':.[0-9]*') #For debug
+STATUS=$(grep -o '"status":.[0-9]*' test.json | head -1  | grep ':.[0-9]*') #Fetch the status of master build
+
+echo "--------------------------------------------"
+echo "Polling for the tests run build status..."
+echo "ux-test-platform build run in progress: https://travis-ci.org/Pearson-Higher-Ed/ux-test-platform/builds/$BUILD_ID"
+
+get_state_value=${STATE#*:}
+STATE="${get_state_value//\"}"
+
+get_status_value=${STATUS#*:}
+STATUS="${get_status_value//\"}"
+
+if [ $STATUS == "0" ] #Success condition
+then
+  echo "counter-> $i"
+  echo "TESTS RUN... PASSED :-) "
+  break #As soon as the tests run pass, we break and return back to the elements build run
+elif [ $STATUS == "1" ] #Failure condition
+then
+ echo "TESTS RUN... FAILED :-("
+ exit 1 #As soon as the tests run fail, we stop building elements
+elif [[ $STATE == "finished" && $STATUS == "n" ]] #Unexpected failure due to Travis environment issues
+then
+ echo "TESTS RUN... NULL :-("
+ exit 1 #For some reason, if the ux-test-platform build breaks or halts
+elif [ $i == "900" ] #Maxed out condition
+  then
+  echo "ux-test-platform run time has maxed out..."
+  exit 1 #Selenium tests run for more than the max time.
+fi
+
+true $(( i++ ))
+sleep 1 #This 1s is required to poll the build status for every second
+echo "counter-> $i"
+done


### PR DESCRIPTION
- Add more info to the Travis API that will trigger ux-test-platform's contextual-help test suite only.
- And export feature branch name to ux-test-platform, that way the tests point to feature_branch of contextual-help only.