### PR TITLE
chore: Enable source maps for webpack dev server.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-- 5.2
 - 4.2
 script:
 - npm run ci

--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ document.getElementById('o-contextual-help-drawer').addEventListener('oDrawer.op
 });
 ```
 
+### How do I debug?
+
+Source maps are enabled for the webpack dev server. Using **Chrome dev tools** - open the "Sources" tab, navigate to 
+`top/webpack://./`, and you will find the original source files for which you can set breakpoints in Chrome's debugger.
+
 ## Accessibility
 
 The module will automatically update `aria-expanded` depending on the state of the target element.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "./node_modules/karma/bin/karma start karma.conf.js",
     "build": "webpack -p",
     "dev-setup": "mkdir -p fonts && cp ./node_modules/pearson-elements/dist/fonts/* ./fonts",
-    "dev": "npm run dev-setup && webpack-dev-server --devtool eval --hot --progress --colors",
+    "dev": "npm run dev-setup && webpack-dev-server --devtool source-map --hot --progress --colors",
     "version": "npm run gen-changelog && git add CHANGELOG.md",
     "ci": "npm run build",
     "gen-changelog": "node ./npm_scripts/gen-changelog.js",


### PR DESCRIPTION
Also removes Node 5 from .travis.yml, as it is not a long term support version.