### PR TITLE
Prevent repeated CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The clickable elements which reveal/hide the content must be buttons, however th
 <h3>
   <button class="o-disclosure" aria-controls="...an id here..." aria-expanded="false">
     <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" class="pe-icon--pivot-close-18">
-      <use xlink:href="/icons/p-icons-sprite-1.1.svg#pivot-close-18"></use>
+      <use xlink:href="#pivot-close-18"></use>
     </svg>
     Heading Text Here
   </button>

--- a/main.scss
+++ b/main.scss
@@ -1,4 +1,3 @@
-@import 'node_modules/@pearson-components/drawer/main';
 @import 'node_modules/pearson-elements/scss/base/variables';
 @import 'node_modules/pearson-elements/scss/elements/color/variables';
 @import 'node_modules/pearson-elements/scss/elements/typography/variables';

--- a/main.scss
+++ b/main.scss
@@ -1,5 +1,7 @@
 @import 'node_modules/@pearson-components/drawer/main';
-@import 'node_modules/pearson-elements/scss/elements';
+@import 'node_modules/pearson-elements/scss/base/variables';
+@import 'node_modules/pearson-elements/scss/elements/color/variables';
+@import 'node_modules/pearson-elements/scss/elements/typography/variables';
 
 /* drawer element */
 .o-contextual-help__drawer.o-drawer {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.1.0",
     "node-sass": "^3.4.2",
-    "pearson-elements": "^1.0.2",
+    "pearson-elements": "^1.0.5",
     "phantomjs-prebuilt": "^2.1.7",
     "sass-loader": "^3.2.0",
     "style-loader": "^0.13.0",


### PR DESCRIPTION
I don't know how to change the order of code, since "drawer" css is called *after* con-help css (this needs to change!), but I removed the "import drawer css" from the main.scss because apparently it is not what adds drawer css to the page.
Additionally I tried only importing the variables files from elements instead of elements.scss so I have access to all variables but not adding in new code.

Check @wyseguyonline @JasonLantz @mhomolak @umahaea 