### PR TITLE
Back up the version of the Drawer from 2.1.5. A change in that versio…

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "postpublish": "npm access public && echo 'Package scope set to public!'"
   },
   "devDependencies": {
-    "@pearson-components/drawer": "~2.1.3",
+    "@pearson-components/drawer": "2.1.4",
     "@pearson-components/elements-sdk": "^2.0.3",
     "@pearson-components/npm-scripts": "^0.5.8",
     "autoprefixer": "^7.2.4",


### PR DESCRIPTION
…n commented out the import of ReactDOM. This breaks IES's use of the help component.