### PR TITLE
Fix accessibility issue with ContextualHelp and screen readers

### DIFF
--- a/src/js/ContextualHelp.js
+++ b/src/js/ContextualHelp.js
@@ -77,6 +77,7 @@ class ContextualHelp extends Component {
         skipTo={skipTo}
         text={{
           headerTitle       : text.headerTitle,
+          headerTitleSR     : (text.headerTitleSR || text.headerTitle),
           closeButtonSRText : text.closeButton,
           backButtonText    : text.backButton
         }}


### PR DESCRIPTION
Updated ContextualHelp component to make use of the Drawer component's screen reader text.

Prefers a separate label, falling back to using the primary non-screen-reader text when no screen reader specific text is present.

This helps avoid an accessibility issue with ContextualHelp component not being correctly announced by a screen reader.